### PR TITLE
stop sending duplicates in KinesisRamp

### DIFF
--- a/motorway/contrib/amazon_kinesis/ramps.py
+++ b/motorway/contrib/amazon_kinesis/ramps.py
@@ -186,11 +186,12 @@ class KinesisRamp(Ramp):
                             self.insertion_queue.put(record)
                         iterator = result['NextShardIterator']
                     else:
+                        next_iterator_number = latest_item if latest_item else str(control_record['checkpoint'])
                         iterator = self.conn.get_shard_iterator(
                             self.stream_name,
                             shard_id,
                             "AT_SEQUENCE_NUMBER",
-                            starting_sequence_number=str(control_record['checkpoint'])
+                            starting_sequence_number=next_iterator_number
                         )['ShardIterator']
 
                     # Push metrics to CloudWatch


### PR DESCRIPTION
When we have too many uncompleted items we should get the next iterator from the latest item we already sent forward, instead of the latest item we got success from. This will stop the ramp sending duplicate messages in case the intersection is not keeping up.