### PR TITLE
Log warnings when internal queue is full

### DIFF
--- a/motorway/messages.py
+++ b/motorway/messages.py
@@ -3,6 +3,8 @@ import multiprocessing
 import traceback
 import uuid
 import datetime
+
+import zmq.backend.cython.constants
 from isodate import duration_isoformat
 from motorway.utils import DateTimeAwareJsonEncoder
 import logging
@@ -81,8 +83,10 @@ class Message(object):
             self.producer_uuid = producer_uuid
         elif not self.producer_uuid:
             assert self.producer_uuid
-        queue.send(
-            self.as_json()
+
+        queue.send_string(
+            self.as_json(),
+            flags=zmq.backend.cython.constants.NOBLOCK
         )
 
     def send_control_message(self, controller_queue, time_consumed=None, process_name=None, destination_endpoint=None,
@@ -113,7 +117,7 @@ class Message(object):
             'producer_uuid': self.producer_uuid,
             'destination_endpoint': destination_endpoint,
             'destination_uuid': destination_uuid
-        })
+        }, flags=zmq.backend.cython.constants.NOBLOCK)
 
     def ack(self, time_consumed=None):
         """

--- a/motorway/messages.py
+++ b/motorway/messages.py
@@ -86,7 +86,7 @@ class Message(object):
 
         queue.send_string(
             self.as_json(),
-            flags=zmq.backend.cython.constants.NOBLOCK
+            flags=zmq.backend.cython.constants.NOBLOCK # Raise and exception if the queue is full.
         )
 
     def send_control_message(self, controller_queue, time_consumed=None, process_name=None, destination_endpoint=None,

--- a/motorway/mixins.py
+++ b/motorway/mixins.py
@@ -1,6 +1,7 @@
 import datetime
 
 import itertools
+import logging
 import random
 import socket
 import uuid
@@ -12,6 +13,9 @@ from motorway.exceptions import SocketBlockedException
 from motorway.grouping import HashRingGrouper, RandomGrouper, GroupingValueMissing, SendToAllGrouper
 from motorway.messages import Message
 from motorway.utils import set_timeouts_on_socket, get_connections_block, get_ip
+
+
+logger = logging.getLogger(__name__)
 
 
 class GrouperMixin(object):
@@ -44,10 +48,17 @@ class SendMessageMixin(object):
         except GroupingValueMissing:
             raise GroupingValueMissing("Message '%s' provided an invalid grouping_value: '%s'" % (message.content, message.grouping_value))
         for destination in socket_addresses:
-            message.send(
-                self.send_socks[destination],
-                process_id
-            )
+            for index in range(0, retries):
+                try:
+                    message.send(
+                        self.send_socks[destination],
+                        process_id
+                    )
+                    break
+                except zmq.Again:
+                    logger.warning("Failed to send message from %s (%s/%s)", process_id, index, retries)
+                    time.sleep(10)
+
             if self.controller_sock and self.send_control_messages and control_message:
                 for index in xrange(0, retries):
                     try:
@@ -59,8 +70,9 @@ class SendMessageMixin(object):
                             destination_endpoint=destination,
                             sender=sender
                         )
-                        break
+                        break  # Exit retry
                     except KeyError:  # If destination is not known, lookup fails
+                        logger.warning("Destination unknown for message %s, sender %s", message, sender)
                         time.sleep(random.randrange(1, 3))  # random to avoid peak loads when running multiple processes
                     except zmq.Again:  # If connection fails, retry
                         time.sleep(random.randrange(1, 3))

--- a/motorway/mixins.py
+++ b/motorway/mixins.py
@@ -49,7 +49,7 @@ class SendMessageMixin(object):
             raise GroupingValueMissing("Message '%s' provided an invalid grouping_value: '%s'" % (message.content, message.grouping_value))
         for destination in socket_addresses:
             # Keep trying to send the message until successful
-            retries = 0
+            message_retries = 0
             while True:
                 try:
                     message.send(
@@ -59,12 +59,12 @@ class SendMessageMixin(object):
                     break
                 # Queue was full or not available
                 except zmq.Again as e:
-                    retries +=1
-                    logger.warning("Failed to send message from %s (retry # %s)", process_id, retries)
+                    message_retries +=1
+                    logger.warning("Failed to send message from %s (retry # %s)", process_id, message_retries)
                     time.sleep(5)
 
             if self.controller_sock and self.send_control_messages and control_message:
-                for index in xrange(0, retries):
+                for index in range(0, retries):
                     try:
                         message.send_control_message(
                             self.controller_sock,


### PR DESCRIPTION
Switch from using a blocking call to add messages to the queue, to a using a call that will raise an exception if the message cannot be delivered instantaneously. this gives us the option to log warnings when a queue is full