### PR TITLE
Change starting order of processes

### DIFF
--- a/motorway/pipeline.py
+++ b/motorway/pipeline.py
@@ -115,6 +115,11 @@ class Pipeline(object):
         if self.run_webserver:
             self.add_intersection(WebserverIntersection, '_web_server', grouper_cls=SendToAllGrouper)  # all webservers should receive messages
 
+        # The Controller, Connection, and Webserver-intersection must be started first so any
+        # other intersection and ramp can successfully connect to them.
+        # The list of processes should therefore be reversed to ensure that these intersections are started first.
+        self._processes.reverse()
+
         logger.debug("Running pipeline")
         for process in self._processes:
             process.start()


### PR DESCRIPTION
This fixes the pipeline not being able to start properly using python 3.

We found that the Controller, Connection, and Webserver-intersection must run before any other intersection or ramp is started. Otherwise, the other intersections and ramps will keep sending out messages to connect to the controller/connnection-intersection, which are not being consumed as those intersections are not started yet.

Because they keep sending messages that are not consumed, the number of open files on the system will eventually hit its limit, preventing anything else from starting - e.g. the controller/connection-intersection.

To fix this, we should first start the controller/connetion/webserver-intersection from which we can start all the other intersections and ramps.

This can be achieved by simply reversing the list of processes `_processes`, as these intersections are appended to the very end of the list.

Tested locally and in a staging environment.