### PR TITLE
Fix connectivity issues

### DIFF
--- a/motorway/connection.py
+++ b/motorway/connection.py
@@ -1,10 +1,8 @@
 import calendar
 import logging
 import datetime
-import socket
 
 from motorway.intersection import Intersection
-from motorway.messages import Message
 from motorway.utils import set_timeouts_on_socket, get_ip
 import time
 import zmq

--- a/motorway/connection.py
+++ b/motorway/connection.py
@@ -38,6 +38,10 @@ class ConnectionIntersection(Intersection):
         self.bind_address = bind_address
 
     def process(self, message):
+        """
+        Receives messages from ramps and intersections updating their latest heartbeat
+        and registers intersections as a consumer of the corresponding streams.
+        """
         connection_updates = message.content
         self.process_id_to_name[connection_updates['meta']['id']] = connection_updates['meta']['name']
         for queue, consumers in connection_updates['streams'].items():
@@ -63,6 +67,11 @@ class ConnectionIntersection(Intersection):
         yield
 
     def connection_thread(self, context=None, **kwargs):
+        """
+        Broadcasts available and active connections to all ramps/intersections listening.
+
+        Automatically removes consumers of a stream upon missing heartbeats from the consumer.
+        """
         while not self.receive_port:
             time.sleep(1)
 

--- a/motorway/connection.py
+++ b/motorway/connection.py
@@ -70,8 +70,8 @@ class ConnectionIntersection(Intersection):
 
         # The publish/broadcast socket where clients subscribe to updates
         broadcast_connection_sock = context.socket(zmq.PUB)
-        broadcast_connection_sock.bind(self.bind_address)
         set_timeouts_on_socket(broadcast_connection_sock)
+        broadcast_connection_sock.bind(self.bind_address)
 
         self.queue_processes['_update_connections'] = {
             'streams': ['tcp://%s:%s' % (get_ip(), self.receive_port)],

--- a/motorway/controller.py
+++ b/motorway/controller.py
@@ -1,8 +1,6 @@
-import calendar
 import logging
 import queue
 
-from setproctitle import setproctitle
 from threading import Thread
 import time
 import datetime
@@ -10,7 +8,7 @@ import uuid
 from motorway.decorators import batch_process
 from motorway.messages import Message
 from motorway.intersection import Intersection
-from motorway.utils import percentile_from_dict, set_timeouts_on_socket
+from motorway.utils import percentile_from_dict
 from isodate import parse_duration
 import zmq
 

--- a/motorway/decorators.py
+++ b/motorway/decorators.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 
 logger = logging.getLogger(__name__)
 

--- a/motorway/grouping.py
+++ b/motorway/grouping.py
@@ -1,6 +1,5 @@
 import random
 from motorway.hash_ring import HashRing
-import zmq
 import logging
 
 logger = logging.getLogger(__name__)

--- a/motorway/intersection.py
+++ b/motorway/intersection.py
@@ -165,8 +165,8 @@ class Intersection(GrouperMixin, SendMessageMixin, ConnectionMixin, ThreadRunner
 
         """
         receive_sock = context.socket(zmq.PULL)
-        self.receive_port = receive_sock.bind_to_random_port("tcp://*")
         set_timeouts_on_socket(receive_sock)
+        self.receive_port = receive_sock.bind_to_random_port("tcp://*")
 
         if self.send_control_messages:
             while not self.controller_sock:

--- a/motorway/messages.py
+++ b/motorway/messages.py
@@ -1,5 +1,4 @@
 import json
-import multiprocessing
 import traceback
 import uuid
 import datetime

--- a/motorway/mixins.py
+++ b/motorway/mixins.py
@@ -2,8 +2,6 @@ import datetime
 
 import itertools
 import random
-import socket
-import uuid
 
 import zmq
 import time

--- a/motorway/mixins.py
+++ b/motorway/mixins.py
@@ -69,6 +69,13 @@ class SendMessageMixin(object):
 
 class ConnectionMixin(object):
     def set_send_socks(self, connections, output_queue, context):
+        """
+        Sets the sockets for which any outgoing messages should be sent to.
+
+        :param connections: dict, containing all available queues and streams
+        :param output_queue: str, name of the queue to output messages to
+        :param context: 'zmq.Context'-instance
+        """
         for send_conn in connections[output_queue]['streams']:
             if send_conn not in self.send_socks:
                 send_sock = context.socket(zmq.PUSH)
@@ -88,6 +95,19 @@ class ConnectionMixin(object):
 
     def connection_thread(self, context=None, refresh_connection_stream=None, input_queue=None, output_queue=None,
                           grouper_cls=None, set_controller_sock=True):
+        """
+        Responsible for managing and connecting to 'input_queue' and 'output_queue' for a ramp or rntersection.
+
+        It is also responsible for sending heartbeats to the ConnectionIntersection and marking itself
+        as a consumer of an 'input_queue', which can be either a ramp or intersection.
+
+        :param context: 'zmq.Context'-instance
+        :param refresh_connection_stream: str, TCP-address of the ConnectionIntersection
+        :param input_queue: str, name of the queue to receive messages from
+        :param output_queue: str, name of the queue to output messages to
+        :param grouper_cls: (Optional) Grouper-class inheriting from BaseGrouper
+        :param set_controller_sock: bool, determines whether or not to track messages in the ControllerIntersection
+        """
         refresh_connection_sock = context.socket(zmq.SUB)
         set_timeouts_on_socket(refresh_connection_sock)
         refresh_connection_sock.connect(refresh_connection_stream)

--- a/motorway/mixins.py
+++ b/motorway/mixins.py
@@ -91,9 +91,9 @@ class ConnectionMixin(object):
     def connection_thread(self, context=None, refresh_connection_stream=None, input_queue=None, output_queue=None,
                           grouper_cls=None, set_controller_sock=True):
         refresh_connection_sock = context.socket(zmq.SUB)
-        refresh_connection_sock.connect(refresh_connection_stream)
-        refresh_connection_sock.setsockopt_string(zmq.SUBSCRIBE, '')  # You must subscribe to something, so this means *all*}
         set_timeouts_on_socket(refresh_connection_sock)
+        refresh_connection_sock.connect(refresh_connection_stream)
+        refresh_connection_sock.setsockopt_string(zmq.SUBSCRIBE, u'')  # You must subscribe to something, so this means *all*}
 
         connections = get_connections_block('_update_connections', refresh_connection_sock)
 
@@ -102,6 +102,7 @@ class ConnectionMixin(object):
 
         # Register as consumer of input stream
         update_connection_sock = context.socket(zmq.PUSH)
+        set_timeouts_on_socket(update_connection_sock)
         update_connection_sock.connect(connections['_update_connections']['streams'][0])
         intersection_connection_info = {
             'streams': {
@@ -119,8 +120,8 @@ class ConnectionMixin(object):
         if set_controller_sock:
             connections = get_connections_block('_message_ack', refresh_connection_sock, existing_connections=connections)
             self.controller_sock = context.socket(zmq.PUSH)
-            self.controller_sock.connect(connections['_message_ack']['streams'][0])
             set_timeouts_on_socket(self.controller_sock)
+            self.controller_sock.connect(connections['_message_ack']['streams'][0])
         while True:
             try:
                 connections = refresh_connection_sock.recv_json()

--- a/motorway/mixins.py
+++ b/motorway/mixins.py
@@ -96,7 +96,7 @@ class ConnectionMixin(object):
     def connection_thread(self, context=None, refresh_connection_stream=None, input_queue=None, output_queue=None,
                           grouper_cls=None, set_controller_sock=True):
         """
-        Responsible for managing and connecting to 'input_queue' and 'output_queue' for a ramp or rntersection.
+        Responsible for managing and connecting to 'input_queue' and 'output_queue' for a ramp or intersection.
 
         It is also responsible for sending heartbeats to the ConnectionIntersection and marking itself
         as a consumer of an 'input_queue', which can be either a ramp or intersection.

--- a/motorway/ramp.py
+++ b/motorway/ramp.py
@@ -151,6 +151,9 @@ class Ramp(GrouperMixin, SendMessageMixin, ConnectionMixin, object):
 
         while True:
             if not self.send_socks:
+                # 'self.send_socks' is set in the 'ConnectionMixin' once the corresponding intersection
+                # has successfully connected to the ConnectionIntersection and marked itself as a consumer
+                # of the input stream, which is the ramp in this case.
                 logger.debug("Waiting for send_socks")
                 time.sleep(1)
             elif self.should_run():

--- a/motorway/ramp.py
+++ b/motorway/ramp.py
@@ -3,14 +3,10 @@ import multiprocessing
 from setproctitle import setproctitle
 import datetime
 from threading import Thread
-import uuid
-from motorway.grouping import GroupingValueMissing
-from motorway.messages import Message
 from motorway.mixins import GrouperMixin, SendMessageMixin, ConnectionMixin
-from motorway.utils import set_timeouts_on_socket, get_connections_block
+from motorway.utils import set_timeouts_on_socket
 import zmq
 import time
-import random
 
 
 logger = logging.getLogger(__name__)

--- a/motorway/ramp.py
+++ b/motorway/ramp.py
@@ -126,9 +126,9 @@ class Ramp(GrouperMixin, SendMessageMixin, ConnectionMixin, object):
 
     def receive_replies(self, context=None):
         result_sock = context.socket(zmq.PULL)
+        set_timeouts_on_socket(result_sock)
         self.receive_port = result_sock.bind_to_random_port("tcp://*")
         logger.debug("Result port is %s" % self.receive_port)
-        set_timeouts_on_socket(result_sock)
 
         while True:
             try:

--- a/motorway/threads.py
+++ b/motorway/threads.py
@@ -2,7 +2,6 @@ import logging
 import multiprocessing
 from setproctitle import setproctitle
 import time
-import zmq
 
 logger = logging.getLogger(__name__)
 

--- a/motorway/utils.py
+++ b/motorway/utils.py
@@ -44,9 +44,22 @@ class DateTimeAwareJsonEncoder(JSONEncoder):
 
 
 def set_timeouts_on_socket(scket):
+    # Duration before returning AGAIN-exception when receiving messages
     scket.RCVTIMEO = 10000
+    # Duration before returning AGAIN-exception when trying to send messages
     scket.SNDTIMEO = 10000
+    # How long to keep messages in memory after a socket disconnects
     scket.LINGER = 1000
+
+    # The below two options are important to reconnect failed socket connections
+    # Failed connections can occur when starting many intersections and ramps at once
+    # Connections that time out will keep attempting to reconnect automatically
+
+    # Interval between each ZMTP heartbeat to the socket
+    scket.HEARTBEAT_IVL = 2000
+    # Duration before a socket connection will time out if no heartbeat (PING/PONG) is received
+    # When this happens, the socket will automatically try to reconnect
+    scket.HEARTBEAT_TTL = 200
 
 
 def get_connections_block(queue, refresh_connection_socket, limit=100, existing_connections=None):

--- a/motorway/utils.py
+++ b/motorway/utils.py
@@ -71,6 +71,16 @@ def set_timeouts_on_socket(scket):
 
 
 def get_connections_block(queue, refresh_connection_socket, limit=100, existing_connections=None):
+    """
+    Will keep refreshing the available connections until the selected queue is available within
+    the dictionary of returned connections, or if the max number of retries 'limit' is reached.
+
+    :param queue: str, name of the queue to search for among all connections
+    :param refresh_connection_socket: str, TCP-address of the ConnectionIntersection
+    :param limit: int, number of attempts to receive connections
+    :param existing_connections: (Optional) dict, containing existing connections to include
+    :return: dict, containing all connections fetched from the ConnectionIntersection or 'existing_connections'
+    """
     i = 0
     connections = existing_connections if existing_connections else {}
     while queue not in connections and i < limit:

--- a/motorway/utils.py
+++ b/motorway/utils.py
@@ -44,6 +44,14 @@ class DateTimeAwareJsonEncoder(JSONEncoder):
 
 
 def set_timeouts_on_socket(scket):
+    """
+    Applies a set of options to a socket.
+
+    IMPORTANT: These options should be applied before binding/connecting
+    to a socket, as they will otherwise have no effect!
+
+    :param scket: 'context.socket'-instance
+    """
     # Duration before returning AGAIN-exception when receiving messages
     scket.RCVTIMEO = 10000
     # Duration before returning AGAIN-exception when trying to send messages
@@ -59,7 +67,7 @@ def set_timeouts_on_socket(scket):
     scket.HEARTBEAT_IVL = 2000
     # Duration before a socket connection will time out if no heartbeat (PING/PONG) is received
     # When this happens, the socket will automatically try to reconnect
-    scket.HEARTBEAT_TTL = 200
+    scket.HEARTBEAT_TTL = 500
 
 
 def get_connections_block(queue, refresh_connection_socket, limit=100, existing_connections=None):

--- a/motorway/utils.py
+++ b/motorway/utils.py
@@ -1,7 +1,7 @@
 import decimal
 from json import JSONEncoder
 import datetime
-from isodate import parse_duration, duration_isoformat, datetime_isoformat
+from isodate import duration_isoformat, datetime_isoformat
 import zmq
 import socket
 


### PR DESCRIPTION
This resolves various issues that were discovered after having a larger number of processes running in a pipeline at once.

### Fixed intersections not successfully registering as consumers
We experienced issues with some intersections not being able to register as a consumer of a ramp as the connect-messages sent to the `ConnectionIntersection` were not being delivered but they appeared to be sent.

This was due to the connection between the intersection and `ConnectionIntersection` not being properly established, maybe due to all intersections/ramps attempting to connect to the `ConnectionIntersection` at once when the pipeline is starting.

To fix this, we've added two new socket-options: `HEARTBEAT_IVL` and `HEARTBEAT_TTL`. These will send a heartbeat to the socket at a set interval to check if the connection is active, and if not, it will time out the connection. 

ZMQ will automatically attempt to reestablish the connection after a timeout, which allows the intersection to properly connect to the `ConnectionIntersection`, from which it can register itself as a consumer of the ramp.

### Fixed setting socket options
We use the method `set_timeouts_on_socket` to set some options for a socket when connecting to it. This was not working as we were setting the options **after** having connected to the socket, but this should be set **before** connecting to the socket.


**Other minor additions:**
- Removed unused imports in some files
- Fixed unicode error breaking backwards compatibility with python 2.7
- Added docstrings and comments to important functions and methods