### PR TITLE
Use copy of dict to avoid iteration through a changing dict

### DIFF
--- a/motorway/controller.py
+++ b/motorway/controller.py
@@ -183,7 +183,7 @@ class ControllerIntersection(Intersection):
                 waiting_messages[process] = waiting_messages.get(process, 0) + 1
 
         # Update histograms
-        for process in self.process_statistics.keys():
+        for process in self.process_statistics.copy().keys():
             self.process_statistics[process]['histogram'][(now + datetime.timedelta(minutes=1)).minute] = self.get_default_process_dict()['histogram'][0]  # reset next minute
             self.process_statistics[process]['waiting'] = waiting_messages.get(process, 0)
 


### PR DESCRIPTION
We should use a copy of the dict `self.process_statistics` when iteration through it to avoid `RuntimeError: dictionary changed size during iteration`.

It should be fine to iterate through a copy of the dict here as it's only used for updating the histograms on the web interface.