### PR TITLE
Keep track of messages being processed

### DIFF
--- a/motorway/connection.py
+++ b/motorway/connection.py
@@ -62,7 +62,7 @@ class ConnectionIntersection(Intersection):
                     'heartbeat': current_heartbeat(),
                     'process_name': connection_updates['meta']['name'],
                     'process_id': connection_updates['meta']['id'],
-                    'report_address': connection_updates['meta'].get('report_address', None),
+                    'report_address': connection_updates['meta']['report_address'],
                 }
                 logger.debug("Received heartbeat from %s on queue %s - current value %s" % (consumer, queue, self.queue_processes[queue]['stream_heartbeats'][consumer]))
         yield

--- a/motorway/connection.py
+++ b/motorway/connection.py
@@ -61,7 +61,8 @@ class ConnectionIntersection(Intersection):
                 self.queue_processes[queue]['stream_heartbeats'][consumer] = {
                     'heartbeat': current_heartbeat(),
                     'process_name': connection_updates['meta']['name'],
-                    'process_id': connection_updates['meta']['id']
+                    'process_id': connection_updates['meta']['id'],
+                    'report_address': connection_updates['meta'].get('report_address', None),
                 }
                 logger.debug("Received heartbeat from %s on queue %s - current value %s" % (consumer, queue, self.queue_processes[queue]['stream_heartbeats'][consumer]))
         yield

--- a/motorway/controller.py
+++ b/motorway/controller.py
@@ -35,6 +35,7 @@ class ControllerIntersection(Intersection):
         self.stream_consumers = stream_consumers or {}
         self.ramp_socks = {}
         self.messages = {}  # Dictionary of all messages which are currently "in flight", eg not successful or failed
+        self.messages_being_processed = {}
         self.failed_messages = {}
         self.process_statistics = {}
         self.queue_processes = {}
@@ -82,6 +83,11 @@ class ControllerIntersection(Intersection):
         """
         now = datetime.datetime.now()
         for message in messages:
+
+            if message.content['msg_type'] in ('started_processing', 'finished_processing'):
+                self._update_messages_being_processed(message)
+                continue
+
             original_process = message.producer_uuid
             if original_process not in self.process_statistics:
                 self.process_statistics[original_process] = self.get_default_process_dict()
@@ -153,6 +159,25 @@ class ControllerIntersection(Intersection):
             pass
         yield  # Hack: This is actually done by self.update() to trigger it even if there are no messages and to reduce messages to 1/s
 
+    def _update_messages_being_processed(self, message):
+        if message.process_name not in self.messages_being_processed:
+            self.messages_being_processed[message.content['process_name']] = []
+
+        if message.content['msg_type'] == 'started_processing':
+            self._update_messages_currently_being_processed(message)
+        elif message.content['msg_type'] == 'finished_processing':
+            self._update_messages_finished_processing(message)
+
+    def _update_messages_currently_being_processed(self, message):
+        self.messages_being_processed[message.content['process_name']].append({
+            'ramp_unique_id': message.ramp_unique_id,
+            'init_time': message.content['init_time'],
+            'content': message.content['message_content']
+        })
+
+    def _update_messages_finished_processing(self, message):
+        self.messages_being_processed[message.content['process_name']] = []
+
     def update(self):
         """
         Goes through all in flight messages, update statistics and forward to web intersection
@@ -192,6 +217,7 @@ class ControllerIntersection(Intersection):
             'process_id_to_name': self.process_id_to_name.copy(),
             'process_statistics': self.process_statistics.copy(),
             'stream_consumers': self.stream_consumers.copy(),
+            'messages_being_processed': self.messages_being_processed.copy(),
             'failed_messages': self.failed_messages.copy(),
         }, grouping_value=str(self.process_uuid))
 

--- a/motorway/intersection.py
+++ b/motorway/intersection.py
@@ -198,7 +198,6 @@ class Intersection(GrouperMixin, SendMessageMixin, ConnectionMixin, ThreadRunner
     def report_message_being_processed(self, context=None):
         socket = context.socket(zmq.REP)
         self.report_address = socket.bind_to_random_port('tcp://*')
-        self._wait_for_controller_sock()
 
         while True:
             _ = socket.recv()  # wait for request from WebserverIntersection
@@ -211,7 +210,8 @@ class Intersection(GrouperMixin, SendMessageMixin, ConnectionMixin, ThreadRunner
 
             socket.send_json(json.dumps(msgs_being_processed))
 
-    def _format_message_being_processed(self, message_being_processed):
+    @staticmethod
+    def _format_message_being_processed(message_being_processed):
         msgs_formatted = []
         if isinstance(message_being_processed, list):
             for msg in message_being_processed:

--- a/motorway/intersection.py
+++ b/motorway/intersection.py
@@ -219,12 +219,14 @@ class Intersection(GrouperMixin, SendMessageMixin, ConnectionMixin, ThreadRunner
                     'ramp_unique_id': msg.ramp_unique_id,
                     'content': msg.content,
                     'init_time': msg.init_time.isoformat(),
+                    'grouping_value': msg.grouping_value,
                 })
         else:
             msgs_formatted.append({
                 'ramp_unique_id': message_being_processed.ramp_unique_id,
                 'content': message_being_processed.content,
                 'init_time': message_being_processed.init_time.isoformat(),
+                'grouping_value': message_being_processed.grouping_value,
             })
 
         return msgs_formatted

--- a/motorway/intersection.py
+++ b/motorway/intersection.py
@@ -203,10 +203,9 @@ class Intersection(GrouperMixin, SendMessageMixin, ConnectionMixin, ThreadRunner
             socket.recv()  # wait for request from WebserverIntersection
 
             message_being_processed = self.message_being_processed or []
-            if message_being_processed:
-                message_being_processed = self._format_message_being_processed(message_being_processed)
+            formatted_message_being_processed = self._format_message_being_processed(message_being_processed)
 
-            socket.send_json(json.dumps(message_being_processed))
+            socket.send_json(json.dumps(formatted_message_being_processed))
 
     @staticmethod
     def _format_message_being_processed(message_being_processed):

--- a/motorway/templates/detail.html
+++ b/motorway/templates/detail.html
@@ -14,6 +14,10 @@
         <div class="message-detail-header">
             <h1>Process ID: {{ process }}</h1>
             <h1>Host: {{ hostname }}</h1>
+            <h2>Process state: {{ process_stats.state }}</h2>
+            <h2>Success messages: {{ process_stats.success }}</h2>
+            <h2>Waiting messages: {{ process_stats.waiting }}</h2>
+            <h2>Failed messages: {{ process_stats.failed }}</h2>
         </div>
         <div class="message-detail-list">
             <h2>Messages being processed</h2>

--- a/motorway/templates/detail.html
+++ b/motorway/templates/detail.html
@@ -19,14 +19,16 @@
             <h2>Messages being processed</h2>
             <table>
                 <tr>
-                    <th>Message ID</th>
-                    <th>Message created at</th>
-                    <th>Message content</th>
+                    <th>ID</th>
+                    <th>Created at</th>
+                    <th>Grouping value</th>
+                    <th>Content</th>
                 </tr>
                 {% for msg in messages_being_processed %}
                     <tr>
                         <td>{{ msg.ramp_unique_id }}</td>
                         <td>{{ msg.init_time }}</td>
+                        <td>{{ msg.grouping_value }}</td>
                         <td>{{ msg.content }}</td>
                     </tr>
                 {% endfor %}

--- a/motorway/templates/detail.html
+++ b/motorway/templates/detail.html
@@ -10,21 +10,45 @@
 	<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
 </head>
 <body>
-	<h1>{{ process }}</h1>
-    <h2>Errors</h2>
-    <table width="100%">
-        <tr>
-            <th>Date</th>
-            <th>Message</th>
-            <th>Exception</th>
-        </tr>
-        {% for date, process, exception, message in failed_messages %}
-            <tr>
-                <td>{{ date }}</td>
-                <td><pre>{{ message }}</pre></td>
-                <td><pre>{{ exception }}</pre></td>
-            </tr>
-        {% endfor %}
-    </table>
+    <div class="message-detail">
+        <div class="message-detail-header">
+            <h1>Process ID: {{ process }}</h1>
+            <h1>Host: {{ hostname }}</h1>
+        </div>
+        <div class="message-detail-list">
+            <h2>Messages being processed</h2>
+            <table>
+                <tr>
+                    <th>Message ID</th>
+                    <th>Message created at</th>
+                    <th>Message content</th>
+                </tr>
+                {% for msg in messages_being_processed %}
+                    <tr>
+                        <td>{{ msg.ramp_unique_id }}</td>
+                        <td>{{ msg.init_time }}</td>
+                        <td>{{ msg.content }}</td>
+                    </tr>
+                {% endfor %}
+            </table>
+        </div>
+        <div class="message-detail-list">
+            <h2>Errors</h2>
+            <table>
+                <tr>
+                    <th>Date</th>
+                    <th>Message</th>
+                    <th>Exception</th>
+                </tr>
+                {% for date, process, exception, message in failed_messages %}
+                    <tr>
+                        <td>{{ date }}</td>
+                        <td><pre>{{ message }}</pre></td>
+                        <td><pre>{{ exception }}</pre></td>
+                    </tr>
+                {% endfor %}
+            </table>
+        </div>
+    </div>
 </body>
 </html>

--- a/motorway/templates/style.css
+++ b/motorway/templates/style.css
@@ -280,14 +280,30 @@ body.disconnected #disconnected-message {
  * * * * * * * * * * * * * * * * * *
 */
 
-.failed-message {
-	font-size: 200%;
-	margin: 15px;
-	padding: 15px;
-	border: 1px solid rgba(255,255,255,0.2);
-	border-radius: 5px;
+.message-detail {
+	text-align: center;
 }
 
+.message-detail-header {
+	margin-top: 10px;
+	margin-bottom: 40px;
+}
+
+.message-detail h1 {
+	padding: 10px 0;
+}
+
+.message-detail-list {
+	margin: 15px 0;
+}
+
+.message-detail-list table {
+	padding: 15px;
+	margin: 15px auto;
+	border: 1px solid rgba(255,255,255,0.2);
+	border-radius: 5px;
+	width: 95%;
+}
 
 /*
  * Group

--- a/motorway/utils.py
+++ b/motorway/utils.py
@@ -1,9 +1,11 @@
 import decimal
+from contextlib import contextmanager
 from json import JSONEncoder
 import datetime
+import socket
+
 from isodate import duration_isoformat, datetime_isoformat
 import zmq
-import socket
 
 ramp_result_stream_name = lambda ramp_class_name: "_ramp_result_%s" % ramp_class_name
 
@@ -94,3 +96,13 @@ def get_ip():
     finally:
         s.close()
     return ip
+
+
+@contextmanager
+def message_processing_manager(intersection, message):
+    if intersection.send_control_messages:
+        intersection.message_being_processed = message
+        yield
+        intersection.message_being_processed = None
+    else:
+        yield

--- a/motorway/webserver.py
+++ b/motorway/webserver.py
@@ -96,9 +96,9 @@ class WebserverIntersection(Intersection):
         context = zmq.Context()
         report_socket = context.socket(zmq.REQ)
 
-        with report_socket.connect(socket_address) as conn:  # closes connection upon exit
-            conn.send_string('')
-            messages_being_processed_json = conn.recv_json()
+        report_socket.connect(socket_address)
+        report_socket.send_string('')
+        messages_being_processed_json = report_socket.recv_json()
 
         return [msg for msg in json.loads(messages_being_processed_json)]
 

--- a/motorway/webserver.py
+++ b/motorway/webserver.py
@@ -57,6 +57,7 @@ class WebserverIntersection(Intersection):
                 process=process,
                 hostname=socket.gethostname(),
                 messages_being_processed=self._get_messages_being_processed_for_process(process),
+                process_stats=self.process_statistics.get(process),
                 failed_messages=reversed(sorted([msg for msg in self.failed_messages.values() if
                                  msg[1] == process], key=lambda itm: itm[0])[-20:]),
 


### PR DESCRIPTION
We lack clarity of what message each process is currently processing. This is useful to know for debugging purposes, e.g. if a process is stuck on some message.

This PR introduces the following changes:

**Webserver can request the process to return the message(s) it's currently processing**:
- Added a context manager named `message_processing_manager` to temporarily save what message a process is currently handling on the `Intersection`-class
- Each intersection process will now start an additional thread named `report_message_being_processed` if `send_control_messages=True`
- This thread will open a new socket, which can be used for requesting what message the process is currently handling (based on the value set by the context manager `message_processing_manager`)
- The socket address of the new socket will be broadcasted in the `ConnectionMixin`, which the `WebserverIntersection` will use to communicate with the process
- The `WebserverIntersection` will make a request to the thread `report_message_being_processed` of a process when a client visits the detail-page of the process - which will return the message(s) the process is currently handling, if any

**Updated process detail-page**
- Refactored this page to include a table containing the messages (if any) that is being handled by the process
- Added the hostname of the process to allow easily identifying what instance/host the process is running on
- Added process stats, e.g. number of success/failed/waiting messages, process state, and more
- Updated styling of the page:
![Screen Shot 2022-01-04 at 10 13 53](https://user-images.githubusercontent.com/37534541/148036190-7ca1d972-47b8-4190-94ee-4475d27919ae.png)


