### PR TITLE
Fix removal of stale processes on python 3.x

### DIFF
--- a/motorway/__init__.py
+++ b/motorway/__init__.py
@@ -1,1 +1,1 @@
-version = "3.1.4"
+version = "3.1.5"

--- a/motorway/webserver.py
+++ b/motorway/webserver.py
@@ -128,7 +128,7 @@ class WebserverIntersection(Intersection):
             group['waiting'] = sum([process['waiting'] for process in group['processes'].values()])
             group['time_taken'] = datetime.timedelta()
             group['histogram'] = {str(minute): {'error_count': 0, 'success_count': 0, 'timeout_count': 0, 'processed_count': 0}.copy() for minute in range(0, 60)}.copy()
-            for process_id, process in group['processes'].items():
+            for process_id, process in list(group['processes'].items()):
 
                 # Remove stale processes (those no longer in the connection thread)
                 if process_id not in self.process_id_to_name:


### PR DESCRIPTION
In python 2.x, `dict#items` returns a list, making it possible to iterate over it and delete elements in the source dictionary at the same time.

In 3.x `dict#items` returns a new view of the dictionary’s items ((key, value) pairs), and deleting dictionary values on the fly causes errors.

This little fix restores the behavior found in python 2.x to 3.x, and in one place changes the iterated object from a view of items to a list of them, making it possible to simultaneously iterate over keys and values and remove elements from the source dictionary.